### PR TITLE
WC-165 - When header text overflow two lines, add ellipsis

### DIFF
--- a/listItem.svelte
+++ b/listItem.svelte
@@ -19,6 +19,11 @@
     letter-spacing: 0.75px;
     font-weight: 500;
     margin-bottom: 2px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
   }
 
   .list-item-text {


### PR DESCRIPTION
- The only solution to added ellipses in two or more lines, is using `line-clamp`, but it's still a draft specification: https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp

- Based on [this issue](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp) in stackoverflow I can make the feature using -webkit-line-clamp.
